### PR TITLE
Make release publication retry-safe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,14 +238,24 @@ jobs:
             cat generated-notes.md
           } > release-notes.md
 
-      - name: Create GitHub release
+      - name: Create or update GitHub release
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          gh release create "$GITHUB_REF_NAME" dist/* \
-            --repo "$GITHUB_REPOSITORY" \
-            --verify-tag \
-            --title "Student Directory $GITHUB_REF_NAME" \
-            --notes-file release-notes.md
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" dist/* \
+              --repo "$GITHUB_REPOSITORY" \
+              --clobber
+            gh release edit "$GITHUB_REF_NAME" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "Student Directory $GITHUB_REF_NAME" \
+              --notes-file release-notes.md
+          else
+            gh release create "$GITHUB_REF_NAME" dist/* \
+              --repo "$GITHUB_REPOSITORY" \
+              --verify-tag \
+              --title "Student Directory $GITHUB_REF_NAME" \
+              --notes-file release-notes.md
+          fi


### PR DESCRIPTION
## Summary
- make the GitHub Release publishing step idempotent
- replace existing release assets with `--clobber` on workflow reruns
- refresh the release title and notes instead of failing when the release already exists

## Validation
- actionlint
- YAML parse
- release workflow policy checks
- `git diff --check`

Follow-up to #7 before tagging v0.1.0.