### PR TITLE
Publish multi-architecture container images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
           set -euo pipefail
           test -f .github/workflows/release.yml
           grep -Fq 'image_name="${GITHUB_REPOSITORY,,}"' .github/workflows/release.yml
+          grep -Fq 'uses: docker/setup-qemu-action@v4' .github/workflows/release.yml
           grep -Fq 'platforms: linux/amd64,linux/arm64' .github/workflows/release.yml
           if grep -Fqi '/enterprisedevgroupproject' .github/workflows/release.yml; then
             echo "Release workflow must publish to the current repository package name." >&2
@@ -69,6 +70,9 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v7
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -76,6 +80,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: false
           tags: capstone-1:ci
           cache-from: type=gha

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
           set -euo pipefail
           test -f .github/workflows/release.yml
           grep -Fq 'image_name="${GITHUB_REPOSITORY,,}"' .github/workflows/release.yml
+          grep -Fq 'platforms: linux/amd64,linux/arm64' .github/workflows/release.yml
           if grep -Fqi '/enterprisedevgroupproject' .github/workflows/release.yml; then
             echo "Release workflow must publish to the current repository package name." >&2
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,24 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Verify published platforms
+        shell: bash
+        env:
+          IMAGE: ${{ steps.image.outputs.image }}
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          set -euo pipefail
+          manifest="$(docker buildx imagetools inspect --raw "${IMAGE}@${DIGEST}")"
+
+          for architecture in amd64 arm64; do
+            if ! jq -e --arg architecture "$architecture" \
+              'any(.manifests[]; .platform.os == "linux" and .platform.architecture == $architecture)' \
+              <<< "$manifest" >/dev/null; then
+              echo "Published image is missing linux/${architecture}." >&2
+              exit 1
+            fi
+          done
+
       - name: Attest container provenance
         uses: actions/attest@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,9 @@ jobs:
           image_name="${GITHUB_REPOSITORY,,}"
           echo "image=${REGISTRY}/${image_name}" >> "$GITHUB_OUTPUT"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -129,6 +132,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk update && apk upgrade --no-cache
 
 # Add metadata labels
 LABEL maintainer="dharminpatel,jonathansoriano,matthewbrown,iankellenberger" \
-    version="0.1.0" \
+    version="0.1.1" \
     description="EnterpriseDevGroupProject Spring Boot Application"
 
 # Copy the Maven wrapper and pom.xml first to leverage Docker layer caching

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/patel5d2/CapStone_1/actions/workflows/main.yml/badge.svg)](https://github.com/patel5d2/CapStone_1/actions/workflows/main.yml)
 
-Current release: `v0.1.0`
+Current release: `v0.1.1`
 
 ## 1. Introduction
 
@@ -238,7 +238,7 @@ docker run -p 8080:8080 ghcr.io/patel5d2/capstone_1:latest
 
 Version tags in the form `vX.Y.Z` run the release workflow. A successful run:
 
-- publishes `ghcr.io/patel5d2/capstone_1` with version, major/minor, SHA, and `latest` tags;
+- publishes `ghcr.io/patel5d2/capstone_1` for Linux AMD64 and ARM64 with version, major/minor, SHA, and `latest` tags;
 - creates a GitHub release with the executable JAR, CycloneDX image SBOM, and SHA-256 checksums;
 - records build provenance for both the JAR and container image.
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.jonathansoriano</groupId>
     <artifactId>EnterpriseDevGroupProject</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <name>EnterpriseDevGroupProject</name>
     <description>EnterpriseDevGroupProject</description>
     <url/>


### PR DESCRIPTION
## Summary
- publish GHCR images for `linux/amd64` and `linux/arm64`
- install QEMU before Buildx in CI and release jobs
- validate both architectures during pull-request container builds
- inspect the pushed OCI index and fail the release unless both platform manifests exist
- bump the release version to `0.1.1` and document multi-architecture support

## Root cause
The v0.1.0 release omitted `platforms` from `docker/build-push-action`, so the Ubuntu runner published only `linux/amd64`. Apple Silicon pulls failed with `no matching manifest for linux/arm64/v8`.

## Validation
- 59 Maven tests passed
- actionlint passed
- workflow YAML and release policy checks passed
- local `linux/arm64` image built and Docker reported `linux/arm64`
- local two-platform OCI archive contained `linux/amd64` and `linux/arm64`

## Release
After merge, tag `v0.1.1` to publish the corrected GHCR package and GitHub Release.